### PR TITLE
Changes to save PTZ camera changes to the last preset used.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "canon-ptz",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"api_version": "1.0.0",
 	"keywords": [
 		"ptz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "canon-ptz",
-	"version": "1.0.11",
+	"version": "1.1.0",
 	"api_version": "1.0.0",
 	"keywords": [
 		"ptz",

--- a/src/index.js
+++ b/src/index.js
@@ -608,7 +608,7 @@ instance.prototype.config_fields = function () {
 		{
 			type: 'text',
 			id: 'tallyOnPGMInfo',
-			width: 4,
+			width: 12,
 			label: 'PGM Tally On',
 			value:
 				'Support for Tally On is no longer possible. Instead you can set this up as a trigger, and get additional control',


### PR DESCRIPTION
Provides the ability to quickly save camera settings to the last Used Preset.  Also, enables the last preset settings to be recalled quickly if you wish to recall without saving after any manual camera adjustments were made.  The two companion presets added to the end of the Recall Presets and Saved Presets hopefully clearly demonstrate this feature.  